### PR TITLE
Fix issue where truncation or infinite loop might occur.

### DIFF
--- a/src/ForceUTF8/Encoding.php
+++ b/src/ForceUTF8/Encoding.php
@@ -180,8 +180,13 @@ class Encoding {
       }
       return $text;
     } elseif(is_string($text)) {
+       
+      if ( function_exists('mb_strlen') && ((int) ini_get('mbstring.func_overload')) & 2) {
+         $max = mb_strlen($text,'8bit');
+      } else {
+         $max = strlen($text);
+      }
     
-      $max = strlen($text);
       $buf = "";
       for($i = 0; $i < $max; $i++){
           $c1 = $text{$i};


### PR DESCRIPTION
Text is truncated when calling Encoding::fixUTF8 if mb_strlen is overloading strlen. This is because mb_strlen returns the char length instead of the byte length of the string.
