### PR TITLE
Introduction to PSR-2 Codestyle

### DIFF
--- a/src/ForceUTF8/Encoding.php
+++ b/src/ForceUTF8/Encoding.php
@@ -35,13 +35,13 @@ POSSIBILITY OF SUCH DAMAGE.
  * @link     https://github.com/neitanod/forceutf8
  * @example  https://github.com/neitanod/forceutf8
  * @license  Revised BSD
-  */
+ */
 
 namespace ForceUTF8;
 
-class Encoding {
-    
-  protected static $win1252ToUtf8 = array(
+class Encoding
+{
+    protected static $win1252ToUtf8 = array(
         128 => "\xe2\x82\xac",
 
         130 => "\xe2\x80\x9a",
@@ -74,11 +74,11 @@ class Encoding {
 
         158 => "\xc5\xbe",
         159 => "\xc5\xb8"
-  );
-  
+    );
+
     protected static $brokenUtf8ToUtf8 = array(
         "\xc2\x80" => "\xe2\x82\xac",
-        
+
         "\xc2\x82" => "\xe2\x80\x9a",
         "\xc2\x83" => "\xc6\x92",
         "\xc2\x84" => "\xe2\x80\x9e",
@@ -90,10 +90,10 @@ class Encoding {
         "\xc2\x8a" => "\xc5\xa0",
         "\xc2\x8b" => "\xe2\x80\xb9",
         "\xc2\x8c" => "\xc5\x92",
-        
+
         "\xc2\x8e" => "\xc5\xbd",
-        
-        
+
+
         "\xc2\x91" => "\xe2\x80\x98",
         "\xc2\x92" => "\xe2\x80\x99",
         "\xc2\x93" => "\xe2\x80\x9c",
@@ -106,225 +106,259 @@ class Encoding {
         "\xc2\x9a" => "\xc5\xa1",
         "\xc2\x9b" => "\xe2\x80\xba",
         "\xc2\x9c" => "\xc5\x93",
-        
+
         "\xc2\x9e" => "\xc5\xbe",
         "\xc2\x9f" => "\xc5\xb8"
-  );
-    
-  protected static $utf8ToWin1252 = array(
-       "\xe2\x82\xac" => "\x80",
-       
-       "\xe2\x80\x9a" => "\x82",
-       "\xc6\x92"     => "\x83",
-       "\xe2\x80\x9e" => "\x84",
-       "\xe2\x80\xa6" => "\x85",
-       "\xe2\x80\xa0" => "\x86",
-       "\xe2\x80\xa1" => "\x87",
-       "\xcb\x86"     => "\x88",
-       "\xe2\x80\xb0" => "\x89",
-       "\xc5\xa0"     => "\x8a",
-       "\xe2\x80\xb9" => "\x8b",
-       "\xc5\x92"     => "\x8c",
-       
-       "\xc5\xbd"     => "\x8e",
-       
-       
-       "\xe2\x80\x98" => "\x91",
-       "\xe2\x80\x99" => "\x92",
-       "\xe2\x80\x9c" => "\x93",
-       "\xe2\x80\x9d" => "\x94",
-       "\xe2\x80\xa2" => "\x95",
-       "\xe2\x80\x93" => "\x96",
-       "\xe2\x80\x94" => "\x97",
-       "\xcb\x9c"     => "\x98",
-       "\xe2\x84\xa2" => "\x99",
-       "\xc5\xa1"     => "\x9a",
-       "\xe2\x80\xba" => "\x9b",
-       "\xc5\x93"     => "\x9c",
-       
-       "\xc5\xbe"     => "\x9e",
-       "\xc5\xb8"     => "\x9f"
     );
 
-  static function toUTF8($text){
-  /**
-   * Function Encoding::toUTF8
-   *
-   * This function leaves UTF8 characters alone, while converting almost all non-UTF8 to UTF8.
-   * 
-   * It assumes that the encoding of the original string is either Windows-1252 or ISO 8859-1.
-   *
-   * It may fail to convert characters to UTF-8 if they fall into one of these scenarios:
-   *
-   * 1) when any of these characters:   ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß
-   *    are followed by any of these:  ("group B")
-   *                                    ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶•¸¹º»¼½¾¿
-   * For example:   %ABREPRESENT%C9%BB. «REPRESENTÉ»
-   * The "«" (%AB) character will be converted, but the "É" followed by "»" (%C9%BB) 
-   * is also a valid unicode character, and will be left unchanged.
-   *
-   * 2) when any of these: àáâãäåæçèéêëìíîï  are followed by TWO chars from group B,
-   * 3) when any of these: ðñòó  are followed by THREE chars from group B.
-   *
-   * @name toUTF8
-   * @param string $text  Any string.
-   * @return string  The same string, UTF8 encoded
-   *
-   */
+    protected static $utf8ToWin1252 = array(
+        "\xe2\x82\xac" => "\x80",
 
-    if(is_array($text))
+        "\xe2\x80\x9a" => "\x82",
+        "\xc6\x92" => "\x83",
+        "\xe2\x80\x9e" => "\x84",
+        "\xe2\x80\xa6" => "\x85",
+        "\xe2\x80\xa0" => "\x86",
+        "\xe2\x80\xa1" => "\x87",
+        "\xcb\x86" => "\x88",
+        "\xe2\x80\xb0" => "\x89",
+        "\xc5\xa0" => "\x8a",
+        "\xe2\x80\xb9" => "\x8b",
+        "\xc5\x92" => "\x8c",
+
+        "\xc5\xbd" => "\x8e",
+
+
+        "\xe2\x80\x98" => "\x91",
+        "\xe2\x80\x99" => "\x92",
+        "\xe2\x80\x9c" => "\x93",
+        "\xe2\x80\x9d" => "\x94",
+        "\xe2\x80\xa2" => "\x95",
+        "\xe2\x80\x93" => "\x96",
+        "\xe2\x80\x94" => "\x97",
+        "\xcb\x9c" => "\x98",
+        "\xe2\x84\xa2" => "\x99",
+        "\xc5\xa1" => "\x9a",
+        "\xe2\x80\xba" => "\x9b",
+        "\xc5\x93" => "\x9c",
+
+        "\xc5\xbe" => "\x9e",
+        "\xc5\xb8" => "\x9f"
+    );
+
+    public static function toUTF8($text)
     {
-      foreach($text as $k => $v)
-      {
-        $text[$k] = self::toUTF8($v);
-      }
-      return $text;
-    } elseif(is_string($text)) {
-       
-      if ( function_exists('mb_strlen') && ((int) ini_get('mbstring.func_overload')) & 2) {
-         $max = mb_strlen($text,'8bit');
-      } else {
-         $max = strlen($text);
-      }
-    
-      $buf = "";
-      for($i = 0; $i < $max; $i++){
-          $c1 = $text{$i};
-          if($c1>="\xc0"){ //Should be converted to UTF8, if it's not UTF8 already
-            $c2 = $i+1 >= $max? "\x00" : $text{$i+1};
-            $c3 = $i+2 >= $max? "\x00" : $text{$i+2};
-            $c4 = $i+3 >= $max? "\x00" : $text{$i+3};
-              if($c1 >= "\xc0" & $c1 <= "\xdf"){ //looks like 2 bytes UTF8
-                  if($c2 >= "\x80" && $c2 <= "\xbf"){ //yeah, almost sure it's UTF8 already
-                      $buf .= $c1 . $c2;
-                      $i++;
-                  } else { //not valid UTF8.  Convert it.
-                      $cc1 = (chr(ord($c1) / 64) | "\xc0");
-                      $cc2 = ($c1 & "\x3f") | "\x80";
-                      $buf .= $cc1 . $cc2;
-                  }
-              } elseif($c1 >= "\xe0" & $c1 <= "\xef"){ //looks like 3 bytes UTF8
-                  if($c2 >= "\x80" && $c2 <= "\xbf" && $c3 >= "\x80" && $c3 <= "\xbf"){ //yeah, almost sure it's UTF8 already
-                      $buf .= $c1 . $c2 . $c3;
-                      $i = $i + 2;
-                  } else { //not valid UTF8.  Convert it.
-                      $cc1 = (chr(ord($c1) / 64) | "\xc0");
-                      $cc2 = ($c1 & "\x3f") | "\x80";
-                      $buf .= $cc1 . $cc2;
-                  }
-              } elseif($c1 >= "\xf0" & $c1 <= "\xf7"){ //looks like 4 bytes UTF8
-                  if($c2 >= "\x80" && $c2 <= "\xbf" && $c3 >= "\x80" && $c3 <= "\xbf" && $c4 >= "\x80" && $c4 <= "\xbf"){ //yeah, almost sure it's UTF8 already
-                      $buf .= $c1 . $c2 . $c3;
-                      $i = $i + 2;
-                  } else { //not valid UTF8.  Convert it.
-                      $cc1 = (chr(ord($c1) / 64) | "\xc0");
-                      $cc2 = ($c1 & "\x3f") | "\x80";
-                      $buf .= $cc1 . $cc2;
-                  }
-              } else { //doesn't look like UTF8, but should be converted
-                      $cc1 = (chr(ord($c1) / 64) | "\xc0");
-                      $cc2 = (($c1 & "\x3f") | "\x80");
-                      $buf .= $cc1 . $cc2;
-              }
-          } elseif(($c1 & "\xc0") == "\x80"){ // needs conversion
-                if(isset(self::$win1252ToUtf8[ord($c1)])) { //found in Windows-1252 special cases
-                    $buf .= self::$win1252ToUtf8[ord($c1)];
-                } else {
-                  $cc1 = (chr(ord($c1) / 64) | "\xc0");
-                  $cc2 = (($c1 & "\x3f") | "\x80");
-                  $buf .= $cc1 . $cc2;
+        /**
+         * Function Encoding::toUTF8
+         *
+         * This function leaves UTF8 characters alone, while converting almost all non-UTF8 to UTF8.
+         *
+         * It assumes that the encoding of the original string is either Windows-1252 or ISO 8859-1.
+         *
+         * It may fail to convert characters to UTF-8 if they fall into one of these scenarios:
+         *
+         * 1) when any of these characters:   ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß
+         *    are followed by any of these:  ("group B")
+         *                                    ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶•¸¹º»¼½¾¿
+         * For example:   %ABREPRESENT%C9%BB. «REPRESENTÉ»
+         * The "«" (%AB) character will be converted, but the "É" followed by "»" (%C9%BB)
+         * is also a valid unicode character, and will be left unchanged.
+         *
+         * 2) when any of these: àáâãäåæçèéêëìíîï  are followed by TWO chars from group B,
+         * 3) when any of these: ðñòó  are followed by THREE chars from group B.
+         *
+         * @name toUTF8
+         * @param string $text Any string.
+         * @return string  The same string, UTF8 encoded
+         *
+         */
+
+        if (is_array($text)) {
+            foreach ($text as $k => $v) {
+                $text[$k] = self::toUTF8($v);
+            }
+            return $text;
+        } elseif (is_string($text)) {
+
+            if (function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload')) & 2) {
+                $max = mb_strlen($text, '8bit');
+            } else {
+                $max = strlen($text);
+            }
+
+            $buf = "";
+            for ($i = 0; $i < $max; $i++) {
+                $c1 = $text{$i};
+                if ($c1 >= "\xc0") { //Should be converted to UTF8, if it's not UTF8 already
+                    $c2 = $i + 1 >= $max ? "\x00" : $text{$i + 1};
+                    $c3 = $i + 2 >= $max ? "\x00" : $text{$i + 2};
+                    $c4 = $i + 3 >= $max ? "\x00" : $text{$i + 3};
+                    if ($c1 >= "\xc0" & $c1 <= "\xdf") { //looks like 2 bytes UTF8
+                        if ($c2 >= "\x80" && $c2 <= "\xbf") { //yeah, almost sure it's UTF8 already
+                            $buf .= $c1 . $c2;
+                            $i++;
+                        } else { //not valid UTF8.  Convert it.
+                            $cc1 = (chr(ord($c1) / 64) | "\xc0");
+                            $cc2 = ($c1 & "\x3f") | "\x80";
+                            $buf .= $cc1 . $cc2;
+                        }
+                    } elseif ($c1 >= "\xe0" & $c1 <= "\xef") { //looks like 3 bytes UTF8
+                        if ($c2 >= "\x80" && $c2 <= "\xbf" && $c3 >= "\x80" && $c3 <= "\xbf") { //yeah, almost sure it's UTF8 already
+                            $buf .= $c1 . $c2 . $c3;
+                            $i = $i + 2;
+                        } else { //not valid UTF8.  Convert it.
+                            $cc1 = (chr(ord($c1) / 64) | "\xc0");
+                            $cc2 = ($c1 & "\x3f") | "\x80";
+                            $buf .= $cc1 . $cc2;
+                        }
+                    } elseif ($c1 >= "\xf0" & $c1 <= "\xf7") { //looks like 4 bytes UTF8
+                        if ($c2 >= "\x80" && $c2 <= "\xbf" && $c3 >= "\x80" && $c3 <= "\xbf" && $c4 >= "\x80" && $c4 <= "\xbf") { //yeah, almost sure it's UTF8 already
+                            $buf .= $c1 . $c2 . $c3;
+                            $i = $i + 2;
+                        } else { //not valid UTF8.  Convert it.
+                            $cc1 = (chr(ord($c1) / 64) | "\xc0");
+                            $cc2 = ($c1 & "\x3f") | "\x80";
+                            $buf .= $cc1 . $cc2;
+                        }
+                    } else { //doesn't look like UTF8, but should be converted
+                        $cc1 = (chr(ord($c1) / 64) | "\xc0");
+                        $cc2 = (($c1 & "\x3f") | "\x80");
+                        $buf .= $cc1 . $cc2;
+                    }
+                } elseif (($c1 & "\xc0") == "\x80") { // needs conversion
+                    if (isset(self::$win1252ToUtf8[ord($c1)])) { //found in Windows-1252 special cases
+                        $buf .= self::$win1252ToUtf8[ord($c1)];
+                    } else {
+                        $cc1 = (chr(ord($c1) / 64) | "\xc0");
+                        $cc2 = (($c1 & "\x3f") | "\x80");
+                        $buf .= $cc1 . $cc2;
+                    }
+                } else { // it doesn't need conversion
+                    $buf .= $c1;
                 }
-          } else { // it doesn't need conversion
-              $buf .= $c1;
-          }
-      }
-      return $buf;
-    } else {
-      return $text;
-    }
-  }
-
-  static function toWin1252($text) {
-    if(is_array($text)) {
-      foreach($text as $k => $v) {
-        $text[$k] = self::toWin1252($v);
-      }
-      return $text;
-    } elseif(is_string($text)) {
-      return utf8_decode(str_replace(array_keys(self::$utf8ToWin1252), array_values(self::$utf8ToWin1252), self::toUTF8($text)));
-    } else {
-      return $text;
-    }
-  }
-
-  static function toISO8859($text) {
-    return self::toWin1252($text);
-  }
-
-  static function toLatin1($text) {
-    return self::toWin1252($text);
-  }
-
-  static function fixUTF8($text){
-    if(is_array($text)) {
-      foreach($text as $k => $v) {
-        $text[$k] = self::fixUTF8($v);
-      }
-      return $text;
+            }
+            return $buf;
+        } else {
+            return $text;
+        }
     }
 
-    $last = "";
-    while($last <> $text){
-      $last = $text;
-      $text = self::toUTF8(utf8_decode(str_replace(array_keys(self::$utf8ToWin1252), array_values(self::$utf8ToWin1252), $text)));
+    public static function toWin1252($text)
+    {
+        if (is_array($text)) {
+            foreach ($text as $k => $v) {
+                $text[$k] = self::toWin1252($v);
+            }
+            return $text;
+        } elseif (is_string($text)) {
+            return utf8_decode(
+                str_replace(
+                    array_keys(self::$utf8ToWin1252),
+                    array_values(self::$utf8ToWin1252),
+                    self::toUTF8($text)
+                )
+            );
+        } else {
+            return $text;
+        }
     }
-    $text = self::toUTF8(utf8_decode(str_replace(array_keys(self::$utf8ToWin1252), array_values(self::$utf8ToWin1252), $text)));
-    return $text;
-  }
-  
-  static function UTF8FixWin1252Chars($text){
-    // If you received an UTF-8 string that was converted from Windows-1252 as it was ISO8859-1 
-    // (ignoring Windows-1252 chars from 80 to 9F) use this function to fix it.
-    // See: http://en.wikipedia.org/wiki/Windows-1252
-    
-    return str_replace(array_keys(self::$brokenUtf8ToUtf8), array_values(self::$brokenUtf8ToUtf8), $text);
-  }
-  
-  static function removeBOM($str=""){
-    if(substr($str, 0,3) == pack("CCC",0xef,0xbb,0xbf)) {
-      $str=substr($str, 3);
-    }
-    return $str;
-  }
-  
-  public static function normalizeEncoding($encodingLabel)
-  {
-    $encoding = strtoupper($encodingLabel);
-    $enc = preg_replace('/[^a-zA-Z0-9\s]/', '', $encoding);
-    $equivalences = array(
-        'ISO88591' => 'ISO-8859-1',
-        'ISO8859'  => 'ISO-8859-1',
-        'ISO'      => 'ISO-8859-1',
-        'LATIN1'   => 'ISO-8859-1',
-        'LATIN'    => 'ISO-8859-1',
-        'UTF8'     => 'UTF-8',
-        'UTF'      => 'UTF-8',
-        'WIN1252'  => 'ISO-8859-1',
-        'WINDOWS1252' => 'ISO-8859-1'
-    );
-    
-    if(empty($equivalences[$encoding])){
-      return 'UTF-8';
-    }
-   
-    return $equivalences[$encoding];
-  }
 
-  public static function encode($encodingLabel, $text)
-  {
-    $encodingLabel = self::normalizeEncoding($encodingLabel);
-    if($encodingLabel == 'UTF-8') return Encoding::toUTF8($text);
-    if($encodingLabel == 'ISO-8859-1') return Encoding::toLatin1($text);
-  }
+    public static function toISO8859($text)
+    {
+        return self::toWin1252($text);
+    }
 
+    public static function toLatin1($text)
+    {
+        return self::toWin1252($text);
+    }
+
+    public static function fixUTF8($text)
+    {
+        if (is_array($text)) {
+            foreach ($text as $k => $v) {
+                $text[$k] = self::fixUTF8($v);
+            }
+            return $text;
+        }
+
+        $last = "";
+        while ($last <> $text) {
+            $last = $text;
+            $text = self::toUTF8(
+                utf8_decode(
+                    str_replace(
+                        array_keys(self::$utf8ToWin1252),
+                        array_values(self::$utf8ToWin1252),
+                        $text
+                    )
+                )
+            );
+        }
+        $text = self::toUTF8(
+            utf8_decode(
+                str_replace(
+                    array_keys(self::$utf8ToWin1252),
+                    array_values(self::$utf8ToWin1252),
+                    $text
+                )
+            )
+        );
+        return $text;
+    }
+
+    public static function UTF8FixWin1252Chars($text)
+    {
+        // If you received an UTF-8 string that was converted from Windows-1252 as it was ISO8859-1
+        // (ignoring Windows-1252 chars from 80 to 9F) use this function to fix it.
+        // See: http://en.wikipedia.org/wiki/Windows-1252
+
+        return str_replace(
+            array_keys(self::$brokenUtf8ToUtf8),
+            array_values(self::$brokenUtf8ToUtf8),
+            $text
+        );
+    }
+
+    public static function removeBOM($str = "")
+    {
+        if (substr($str, 0, 3) == pack("CCC", 0xef, 0xbb, 0xbf)) {
+            $str = substr($str, 3);
+        }
+        return $str;
+    }
+
+    public static function normalizeEncoding($encodingLabel)
+    {
+        $encoding = strtoupper($encodingLabel);
+        $enc = preg_replace('/[^a-zA-Z0-9\s]/', '', $encoding);
+        $equivalences = array(
+            'ISO88591' => 'ISO-8859-1',
+            'ISO8859' => 'ISO-8859-1',
+            'ISO' => 'ISO-8859-1',
+            'LATIN1' => 'ISO-8859-1',
+            'LATIN' => 'ISO-8859-1',
+            'UTF8' => 'UTF-8',
+            'UTF' => 'UTF-8',
+            'WIN1252' => 'ISO-8859-1',
+            'WINDOWS1252' => 'ISO-8859-1'
+        );
+
+        if (empty($equivalences[$encoding])) {
+            return 'UTF-8';
+        }
+
+        return $equivalences[$encoding];
+    }
+
+    public static function encode($encodingLabel, $text)
+    {
+        $encodingLabel = self::normalizeEncoding($encodingLabel);
+        if ($encodingLabel == 'UTF-8') {
+            return Encoding::toUTF8($text);
+        }
+        if ($encodingLabel == 'ISO-8859-1') {
+            return Encoding::toLatin1($text);
+        }
+    }
 }


### PR DESCRIPTION
## What
A change to introduce [PSR-2 codestyle](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).
I've used 2 separate commits on purpose to group the general indentation changes apart from a [small refactoring](https://github.com/david4worx/forceutf8/commit/c41fcdee73e468df73029dc1898f5df5f3d84cc4).

## Why
* Consistent to read code
* Gives better overview
* Helps tools like PHP_CodeSniffer

## Whats changed
* All tabs have been replaced by 4 spaces
* Control structures are now PSR-2 compliant
* Every class method and variable have a declared visibility
* Refactored the if statements for checking/guessing multi-byte strings into separate variables that are re-used
* No line is longer then the hard limit of 80 chars.

## What will come?
* A decrease in cyclomatic complexity (removing not needed else(if) statement and utilizing fast returns)
* Docblox
* A (possible?) fix for an [EURO sign problem](http://nl3.php.net/manual/en/function.utf8-decode.php#88488)