### PR TITLE
Added a new parameter in fixUTF8 method 

### DIFF
--- a/src/ForceUTF8/Encoding.php
+++ b/src/ForceUTF8/Encoding.php
@@ -248,14 +248,14 @@ class Encoding {
     }
   }
 
-  static function toWin1252($text) {
+  static function toWin1252($text, $option = self::WITHOUT_ICONV) {
     if(is_array($text)) {
       foreach($text as $k => $v) {
-        $text[$k] = self::toWin1252($v);
+        $text[$k] = self::toWin1252($v, $option);
       }
       return $text;
     } elseif(is_string($text)) {
-      return static::utf8_decode($text);
+      return static::utf8_decode($text, $option);
     } else {
       return $text;
     }


### PR DESCRIPTION
I am running into problems with this new version that uses iconv. 

I added a new parameter in the fixUTF8 method that allows the user to choose whether to use iconv with //TRANSLIT, //IGNORE or use the old method.
