### PR TITLE
Missing return statement

### DIFF
--- a/src/ForceUTF8/Encoding.php
+++ b/src/ForceUTF8/Encoding.php
@@ -328,9 +328,14 @@ class Encoding {
 
   public static function encode($encodingLabel, $text)
   {
-    $encodingLabel = self::normalizeEncoding($encodingLabel);
-    if($encodingLabel == 'UTF-8') return Encoding::toUTF8($text);
-    if($encodingLabel == 'ISO-8859-1') return Encoding::toLatin1($text);
+     // map the encodings to their own handler methods
+	  $map = array(
+		  'UTF-8' => 'toUTF8',
+		  'ISO-8859-1' => 'toLatin1'
+	  );
+	  // choose the apprpriate method based on the current encoding
+	  $processor = $map[self::normalizeEncoding($encodingLabel)];
+	  return Encoding::$processor($text);
   }
 
   protected static function utf8_decode($text, $option)


### PR DESCRIPTION
This method raises the following error:
== Missing return statement: The method may return a value or end it's execution without a return statement at all ==
It refers to the hypothetical case when $encodingLabel is different from both 'UTF-8' and 'ISO-8859-1' which we know it can't happen, but the php compiler does not take into account the value of the variables at runtime: it only analyzes the code.

To suppress the warning, the algorithm itself should reflect the fact that $encodingLabel can assume only two certain values.
Aside from the code proposed, here follows an alternative implementation, less elegant but simpler to understand, if you prefer it.

	  if (self::normalizeEncoding($encodingLabel) == 'UTF-8')
	  {
		  return Encoding::toUTF8($text);
	  }
	  else // 'ISO-8859-1'
	  {
		  return Encoding::toLatin1($text);
	  }