### PR TITLE
Fix fixUTF8() cast

### DIFF
--- a/src/ForceUTF8/Encoding.php
+++ b/src/ForceUTF8/Encoding.php
@@ -274,6 +274,10 @@ class Encoding {
       return $text;
     }
 
+    if(!is_string($text)) {
+      return $text;
+    }
+
     $last = "";
     while($last <> $text){
       $last = $text;


### PR DESCRIPTION
The method fixUTF8() casts all the values of an array to string (int, float, bool).