### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/test/Test.class.php
+++ b/test/Test.class.php
@@ -5,7 +5,7 @@
     protected static $last_echoed;
 
     public static function true($test_name, $result){
-      return static::is($test_name, $result, TRUE);
+      return static::is($test_name, $result, true);
     }
 
     public static function is($test_name, $result, $expected){


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!