### PR TITLE
replace curly braces with square brackets for PHP 7.4 compatibility

### DIFF
--- a/src/ForceUTF8/Encoding.php
+++ b/src/ForceUTF8/Encoding.php
@@ -193,11 +193,11 @@ class Encoding {
 
     $buf = "";
     for($i = 0; $i < $max; $i++){
-        $c1 = $text{$i};
+        $c1 = $text[$i];
         if($c1>="\xc0"){ //Should be converted to UTF8, if it's not UTF8 already
-          $c2 = $i+1 >= $max? "\x00" : $text{$i+1};
-          $c3 = $i+2 >= $max? "\x00" : $text{$i+2};
-          $c4 = $i+3 >= $max? "\x00" : $text{$i+3};
+          $c2 = $i+1 >= $max? "\x00" : $text[$i+1];
+          $c3 = $i+2 >= $max? "\x00" : $text[$i+2];
+          $c4 = $i+3 >= $max? "\x00" : $text[$i+3];
             if($c1 >= "\xc0" & $c1 <= "\xdf"){ //looks like 2 bytes UTF8
                 if($c2 >= "\x80" && $c2 <= "\xbf"){ //yeah, almost sure it's UTF8 already
                     $buf .= $c1 . $c2;


### PR DESCRIPTION
PHP 7.4 [deprecates](https://wiki.php.net/rfc/deprecate_curly_braces_array_access) the usage of curly braces for array/string access.

ForceUTF8 uses curly braces in the [`toUTF8()`](https://github.com/neitanod/forceutf8/blob/c4222087168fe8476bde930e2ad04d111f36f53b/src/ForceUTF8/Encoding.php#L196-L200) method.

Running the [test script](https://github.com/neitanod/forceutf8/blob/master/test/ForceUTF8Test.php) with PHP 7.4.0RC4 and full error reporting enabled shows multiple deprecation warnings:

``` shell script
PHP_VERSION=7.4.0RC4-cli ; docker run --tty --rm \
--name "$PHP_VERSION" \
-v "$PWD":"/usr/src/php-$PHP_VERSION" \
-w "/usr/src/php-$PHP_VERSION" \
"php:$PHP_VERSION" \
php -d error_reporting=E_ALL test/ForceUTF8Test.php

Deprecated: Array and string offset access syntax with curly braces is deprecated in /usr/src/php-7.4.0RC4-cli/src/ForceUTF8/Encoding.php on line 196

Deprecated: Array and string offset access syntax with curly braces is deprecated in /usr/src/php-7.4.0RC4-cli/src/ForceUTF8/Encoding.php on line 198

Deprecated: Array and string offset access syntax with curly braces is deprecated in /usr/src/php-7.4.0RC4-cli/src/ForceUTF8/Encoding.php on line 199

Deprecated: Array and string offset access syntax with curly braces is deprecated in /usr/src/php-7.4.0RC4-cli/src/ForceUTF8/Encoding.php on line 200
.................
17 tests passed.
0 tests failed.
```

This pull request changes all occurrences to square brackets.
