### PR TITLE
do not repeat the last step again for fixUTF8

### DIFF
--- a/src/ForceUTF8/Encoding.php
+++ b/src/ForceUTF8/Encoding.php
@@ -283,7 +283,6 @@ class Encoding {
       $last = $text;
       $text = self::toUTF8(static::utf8_decode($text, $option));
     }
-    $text = self::toUTF8(static::utf8_decode($text, $option));
     return $text;
   }
 


### PR DESCRIPTION
this is a small improvement, but using this function in a loop with large texts it is an improvement