### PR TITLE
Use multiple flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ will output:
     Fédération Camerounaise de Football
     Fédération Camerounaise de Football
     
-Options:
+Flags:
 ========
 By default, `Encoding::fixUTF8` will use the `Encoding::WITHOUT_ICONV` flag, signalling that iconv should not be used to fix garbled UTF8 strings.
 
-This class also provides options for iconv processing, such as `Encoding::ICONV_TRANSLIT` and `Encoding::ICONV_IGNORE` to enable these flags when the iconv class is utilized. The functionality of such flags are documented in the [PHP iconv documentation](http://php.net/manual/en/function.iconv.php).
+This class also provides flags for iconv processing, such as `Encoding::ICONV_TRANSLIT` and `Encoding::ICONV_IGNORE` to enable these flags when the iconv class is utilized. The functionality of such flags are documented in the [PHP iconv documentation](http://php.net/manual/en/function.iconv.php).
 
 Examples:
 
@@ -61,10 +61,12 @@ Examples:
     echo Encoding::fixUTF8($str); // Will break U+2014
     echo Encoding::fixUTF8($str, Encoding::ICONV_IGNORE); // Will preserve U+2014
     echo Encoding::fixUTF8($str, Encoding::ICONV_TRANSLIT); // Will preserve U+2014
+    echo Encoding::fixUTF8($str, Encoding::ICONV_TRANSLIT | Encoding::ICONV_IGNORE); // Will preserve U+2014
 
 will output:
 
     Fédération Camerounaise?de?Football
+    Fédération Camerounaise—de—Football
     Fédération Camerounaise—de—Football
     Fédération Camerounaise—de—Football
 
@@ -76,11 +78,13 @@ while:
     echo Encoding::fixUTF8($str); // Will break invalid characters
     echo Encoding::fixUTF8($str, Encoding::ICONV_IGNORE); // Will remove invalid characters, keep those present in Win1252
     echo Encoding::fixUTF8($str, Encoding::ICONV_TRANSLIT); // Will trasliterate invalid characters, keep those present in Win1252
+    echo Encoding::fixUTF8($str, Encoding::ICONV_TRANSLIT | Encoding::ICONV_IGNORE); // Will trasliterate invalid (but legal) characters, remove illegal character in input string, keep those present in Win1252
 
 will output:
 
     ????????
     šž
+    ceeišuuž
     ceeišuuž
 
 

--- a/test/ForceUTF8Test.php
+++ b/test/ForceUTF8Test.php
@@ -97,5 +97,8 @@ Test::identical("fixUTF8() Example 3 still working.",
 Test::identical("fixUTF8() Example 4 still working.",
   Encoding::fixUTF8("FÃÂÂÂÂ©dÃÂÂÂÂ©ration Camerounaise de Football\n"),
   "Fédération Camerounaise de Football\n");
+Test::identical("fixUTF8() Example 5 still working.",
+    Encoding::fixUTF8("À \n"),
+    "À \n");
 
 Test::totals();


### PR DESCRIPTION
In some cases it may be useful to use both `//TRANSLIT` and `//IGNORE` to avoid

```
iconv(): Detected an illegal character in input string
```
but keep transliterate.

I suggest to change `option` to `flags` to use Encoding with `Encoding::ICONV_TRANSLIT`, `Encoding::ICONV_IGNORE` or both (`Encoding::ICONV_TRANSLIT | Encoding::ICONV_IGNORE`) like [`preg_match`](https://www.php.net/manual/fr/function.preg-match.php), [`extract`](https://www.php.net/manual/fr/function.extract.php), [`PDOStatement::fetch`](https://www.php.net/manual/fr/pdostatement.fetch.php)...